### PR TITLE
Feat: Improve search precision with field-specific queries and filters

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,15 +21,34 @@ date_range_days: 7
 # 최대 검색 결과 수 (키워드당)
 max_results_per_keyword: 20
 
+# ─── 검색 정밀도 필터 ─────────────────────────────────────
+# Semantic Scholar: fieldsOfStudy 필터 (비워두면 전체)
+# 가능한 값: Computer Science, Engineering, Physics, Mathematics, Medicine, Biology, ...
+fields_of_study:
+  - "Computer Science"
+  - "Engineering"
+
+# arxiv: 카테고리 필터 (비워두면 전체)
+# AI/ML/CV/Robotics 관련 주요 카테고리:
+#   cs.AI, cs.CV, cs.RO, cs.LG, cs.CL, cs.MA, cs.NE, cs.HC, eess.SY
+arxiv_categories:
+  - "cs.AI"
+  - "cs.CV"
+  - "cs.RO"
+  - "cs.LG"
+  - "cs.CL"
+  - "cs.MA"
+  - "cs.NE"
+
 # ─── 학회/venue 필터 ───────────────────────────────────────
 # 비워두면 전체 검색 (필터 없음)
 # Semantic Scholar venue 이름 기준
 venues:
   # - "ArXiv"
-  - "CVPR"
-  - "ICCV"
-  - "ECCV"
-  - "NeurIPS"
+  # - "CVPR"
+  # - "ICCV"
+  # - "ECCV"
+  # - "NeurIPS"
   # - "ICML"
   # - "ICLR"
   # - "AAAI"

--- a/main.py
+++ b/main.py
@@ -118,6 +118,8 @@ def main():
         max_results_per_keyword=cfg.get("max_results_per_keyword", 20),
         venues=cfg.get("venues") or [],
         s2_api_key=os.environ.get("S2_API_KEY", ""),
+        fields_of_study=cfg.get("fields_of_study") or [],
+        arxiv_categories=cfg.get("arxiv_categories") or [],
     )
 
     logger.info("Step 1: Searching papers...")


### PR DESCRIPTION
## Summary

- arxiv 검색 시 `all:` 대신 `ti:` / `abs:` 필드 지정 쿼리로 변경하여 제목·초록 기반 정밀 검색 지원
- Semantic Scholar `fieldsOfStudy` 필터 및 arxiv 카테고리(`cat:`) 필터 추가
- `config.yaml`에 `fields_of_study`, `arxiv_categories` 설정 항목 추가

## Changes

- **searcher.py**: `_normalize_keyword`에서 arxiv 쿼리를 `(ti:"term" OR abs:"term")` 형태로 변경, `search_semantic_scholar`에 `fieldsOfStudy` 파라미터 추가, `search_arxiv`에 카테고리 필터 결합 로직 추가
- **main.py**: `SearchConfig` 생성 시 `fields_of_study`, `arxiv_categories` 전달
- **config.yaml**: `fields_of_study`, `arxiv_categories` 설정 섹션 추가, 기존 venues 필터 주석 처리